### PR TITLE
Fix bans and add virus shot speed (config)

### DIFF
--- a/src/core/ConfigService.js
+++ b/src/core/ConfigService.js
@@ -130,6 +130,7 @@ module.exports = class ConfigService {
       virusExplosionMult: 0.86,
       virusStartMass: 100, // Starting virus size (In mass)
       virusFeedAmount: 7, // Amount of times you need to feed a virus to shoot it
+      virusShotSpeed: 135, // Speed of a virus shot
       motherCellMassProtection: 1, // Stopping mothercells from being too big (0 to disable)
       motherCellMaxMass: 10000, // Max mass of a mothercell
       ejectMass: 12, // Mass of ejected cells

--- a/src/core/GameServer.js
+++ b/src/core/GameServer.js
@@ -1480,7 +1480,7 @@ onWVerify(client) {
 
     let newVirus = new Entity.Virus(this.world.getNextNodeId(), null, parentPos, this.config.virusStartMass);
     newVirus.setAngle(parent.getAngle());
-    newVirus.setMoveEngineData(200, 20);
+    newVirus.setMoveEngineData(this.config.virusShotSpeed, 20, 0.85);
 
     // Add to moving cells list
     this.addNode(newVirus, "moving");

--- a/src/core/GameServer.js
+++ b/src/core/GameServer.js
@@ -153,10 +153,6 @@ this.name = name;
       name: "none"
     };
 
-
-    this.banned = [];
-
-
     this.leaderboard = []; // leaderboard
     this.lb_packet = new ArrayBuffer(0); // Leaderboard packet
     this.largestClient = undefined;

--- a/src/settings/config.ini
+++ b/src/settings/config.ini
@@ -135,6 +135,7 @@ borderBottom = 10000
 // virusStartMass : Starting virus size (in mass).
 // virusFeedAmount : Amount of times you need to feed a virus to shoot it.
 // virusExplosionMult : Distance the cells will travel when it consumes a virus(0.86 is default, Its not suggested to go over 2 or the cells will bounce across the map!)
+// virusShotSpeed : Speed of a virus shot.
 foodSpawnAmount = 240
 foodStartAmount = 500
 foodMaxAmount = 1000
@@ -149,6 +150,7 @@ virusMaxAmount = 50
 virusStartMass = 100
 virusFeedAmount = 7
 virusExplosionMult = 0.86
+virusShotSpeed = 135
 ======================================================================================================================================================
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ======================================================================================================================================================


### PR DESCRIPTION
- Bans were broken because `this.banned = [] `was overriding the bans pulled in from banned.txt.
- Added config for virus shot speed, slowed them down to 135 by default, with a decay of 0.85.

Note regarding virus shot speeds after extensive testing: it seems that when you shoot at a virus with multiple cell pieces, the virus movement speed trips out (you'll also see teleporting viruses). Must have something to do with the physics / movement engine.