### PR TITLE
Small but annoying bug fix

### DIFF
--- a/src/modules/commands/kickbots.js
+++ b/src/modules/commands/kickbots.js
@@ -10,4 +10,5 @@ module.exports = function (gameServer, split) {
   }
 gameServer.sbo -= removed;
   console.log("[Console] Kicked " + toRemove + " bots");
+  return;
 };


### PR DESCRIPTION
Disallow bots to respawn when the **``kickbots [amount]``** is ran.

I have read and agreed to the contributing guidelines

